### PR TITLE
add missing email domains

### DIFF
--- a/generate/domains.txt
+++ b/generate/domains.txt
@@ -5278,6 +5278,7 @@ mailbox.as
 mailbox.co.za
 mailbox.gr
 mailbox.hu
+mailbox.org
 mailbox.r2.dns-cloud.net
 mailbox2go.de
 mailbox52.ga
@@ -6390,6 +6391,7 @@ ploae.com
 plusmail.com.br
 plutocow.com
 plw.me
+pm.me
 pmail.net
 po.bot.nu
 pobox.com
@@ -6487,6 +6489,7 @@ primposta.com
 primposta.hu
 privacy.net
 privatdemail.net
+privaterelay.appleid.com
 privy-mail.com
 privy-mail.de
 privymail.de
@@ -6514,6 +6517,7 @@ proprietativalcea.ro
 propscore.com
 protestant.com
 proto2mail.com
+protonmail.ch
 protonmail.com
 providier.com
 provmail.net


### PR DESCRIPTION
few common email providers were missing in the list, namely `mailbox.org, pm.me, privaterelay.appleid.com, and protonmail.ch`